### PR TITLE
Require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/arteck/ioBroker.seq"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "seq-logging": "^2.1.1"


### PR DESCRIPTION
adapter-core 3.x.x is known to fail with node 14 or older. So this adapter requires node 16 minimum